### PR TITLE
Fix action warning and enhanced readme styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,20 @@ jobs:
 ### Input options
 
 | Option | Value | Description | Default |
-| :--- | :---: | :--- | :---: |
+| :--- | :--- | :--- | :--- |
 | **check_library**  | `enable`, `disable` | Show information messages when library files have incomplete info | `disable` |
 | **skip_preprocessor** | `enable`, `disable` | Print preprocessor output on stdout and don't do any further processing | `disable` |
-| **enable** | `all`, `warning`, `style`, `performance`, `portability`, `information` ,`unusedFunction` ,`missingInclude` | Enable additional checks. if you want to enable multiple checking at once, separate them using `,` without any blank space. example: `style,warning,performance` | `all` |
+| **enable** | `all`, `warning`, `style`, `performance`, `portability`, `information`, `unusedFunction`, `missingInclude` | Enable additional checks. if you want to enable multiple checking at once, separate them using `,` without any blank space. example: `style,warning,performance` | `all` |
 | **exclude_check** | `./path/to/ignore` | Give a file or directory path to exclude from checking. example: `./no_check.cpp` | nothing to ignore |
 | **inconclusive** | `enable`, `disable` | Allow that Cppcheck reports even though the analysis is inconclusive | `enable` |
 | **inline_suppression** | `enable`, `disable` | Enable inline suppressions. Use them by placing one or more comments, like: '// cppcheck-suppress warningId' | `disable` |
 | **force_language** | `c`, `c++` | Forces cppcheck to check all files as the given language. Valid values are: `c`, `c++` | auto-detected |
 | **force** | `enable`, `disable` | Force checking of all configurations in files | `disable` |
 | **max_ctu_depth** | `number` | Max depth in whole program analysis. A larger value will mean more errors can be found but also means the analysis will be slower. example: `4` | `2` |
-| **platform** | `unix32`, `unix64`, `win32A`, `win32W`, `win64`, `avr8`, `native` | Specifies platform specific types and sizes | `unspecified` |
-| **std** | `c89` ,`c99` , `c11` , `c++11` ,`c++14` ,`c++17`, `c++20` | Set the C/C++ standard | `c++20` |
+| **platform** | `unix32`, `unix64`, `win32A`, `win32W`, `win64`, `avr8`, `elbrus-e1cp`, `pic8`, `pic8-enhanced`, `pic16`, `mips32`, `native`, `unspecified`, | Specifies platform specific types and sizes | `unspecified` |
+| **std** | `c89`, `c99`, `c11`, `c++11`, `c++14`, `c++17`, `c++20` | Set the C/C++ standard | `c11`, `c++20` |
 | **output_file** | `./path/to/output/file.txt` | Give a filename for the output report | `./cppcheck_report.txt` |
+
 
 <b> For further details check
 [cppcheck documentations](http://cppcheck.sourceforge.net/manual.pdf) </b>

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,11 @@ inputs:
     default: "disable"
     required: false
 
+  force:
+    description: "Force checking of all configurations in files"
+    default: "disable"
+    required: false
+
   max_ctu_depth:
     description: "Max depth in whole program analysis"
     default: "disable"
@@ -62,10 +67,16 @@ inputs:
     default: "disable"
     required: false
 
+  std:
+    description: "Set the C/C++ standard"
+    default: "c++20"
+    required: false
+
   output_file:
-    description: " files where the result to be dumped"
+    description: "file where the result to be dumped"
     default: "cppcheck_report.txt"
     required: false
+
   target_branch:
     description: "Branch that the badge will target. Defaults to the current branch."
     default: ""


### PR DESCRIPTION
- i forget to add new options to `action.yml` in PR #36 which results on an expected input(s) warning in the first line of [cppcheck task](https://github.com/BaderEddineOuaich/Enigma/runs/2296777642), now its solved.
- added all cppcheck platform values to readme table, new values are: `elbrus-e1cp`, `pic8`, `pic8-enhanced`, `pic16`, `mips32`
- added c11 to readme table std default option (--std= can have either c11 or c++20 as default value)